### PR TITLE
Allow fast-find of compendium item IDs

### DIFF
--- a/src/module/lib/lib.ts
+++ b/src/module/lib/lib.ts
@@ -332,12 +332,17 @@ export async function retrieveItemFromData(
     const pack = game.packs.get(currentCompendium);
     if (pack) {
       await pack.getIndex();
-      for (const entityComp of pack.index) {
-        const itemComp = <StoredDocument<Item>>await pack.getDocument(entityComp._id);
-        if (itemComp.id === itemId || itemComp.name === itemName) {
-          itemFounded = itemComp;
-          break;
-        }
+      // Try to find the item by exact ID
+      itemFounded = pack.index.get(itemId);
+      // If not found, search for the item by name
+      if (!itemFounded) {
+        for (const entityComp of pack.index) {
+          const itemComp = <StoredDocument<Item>>await pack.getDocument(entityComp._id);
+          if (itemComp.name === itemName) {
+            itemFounded = itemComp;
+            break;
+          }
+        } 
       }
     }
   }


### PR DESCRIPTION
Looping over the compendium index and `await`ing `.getDocument` for each document in large compendiums can create a noticeable delay on drag-drop. Instead, try to look up the item ID in the compendium's index before resorting to a full search.

Note that this is a "lowest hanging fruit" change, and further performance enhancements may still be possible.